### PR TITLE
reduces mongoose dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple library for creating locks with mongoose.
 npm i lockgoose
 ```
 
-Requires [mongoose](http://mongoosejs.com/) to be installed as a dependency.
+Requires [mongoose](http://mongoosejs.com/) `^5.0.0` to be installed as a dependency.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = (opts = {}) => {
         try {
             await newLock.save();
         } catch (err) {
-            if (err.name === 'MongoError' && err.code === 11000) {
+            if ((err.name === 'MongoError' || err.name === 'BulkWriteError') && err.code === 11000) {
                 throw new LockgooseError('a lock already exists for this tag');
             }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,15 +24,6 @@
                 "js-tokens": "3.0.2"
             }
         },
-        "@hubba/eslint-config-hubba": {
-            "version": "0.2.0",
-            "resolved": "http://npm.hubba.com:8080/@/@hubba/eslint-config-hubba/_attachments/eslint-config-hubba-0.2.0.tgz",
-            "integrity": "sha512-s2XmJedF1vnZvtIYPpNExSddfXPPUCctrg/LUIX915N4NWvOZiBvEyszBZyhtpm9CjyPIEq4nRhaiB//uRTKZg==",
-            "dev": true,
-            "requires": {
-                "eslint-plugin-jasmine": "2.10.1"
-            }
-        },
         "abab": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -1718,12 +1709,6 @@
                     "dev": true
                 }
             }
-        },
-        "eslint-plugin-jasmine": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.10.1.tgz",
-            "integrity": "sha1-VzO3CedR9LxA4x4cFpib0s377Jc=",
-            "dev": true
         },
         "eslint-scope": {
             "version": "3.7.1",
@@ -3913,9 +3898,9 @@
             }
         },
         "kareem": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.1.0.tgz",
-            "integrity": "sha512-ycoMY1tVkcH1/NaxGn2erZaUC3CodmX7Fl6DUVXjN73+uecWYTaaldRkxNY3HeSKQnQTWnoxRKnZfVHcB8tIWg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.0.1.tgz",
+            "integrity": "sha512-SsR+TZe595qXYzbWS5KWHBt4mM5h1MA7HFXp3oZnPkunxjaymx0fKhB8cxl6/R7Qm8aFXnI6J7DnyxV/QUSKLA==",
             "dev": true
         },
         "kind-of": {
@@ -4208,18 +4193,18 @@
             }
         },
         "mongodb": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.8.tgz",
-            "integrity": "sha512-mj7yIUyAr9xnO2ev8pcVJ9uX7gSum5LLs1qIFoWLxA5Il50+jcojKtaO1/TbexsScZ9Poz00Pc3b86GiSqJ7WA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.1.tgz",
+            "integrity": "sha1-J47oAGJX7CJ5hZSmJZVGgl1t4bI=",
             "dev": true,
             "requires": {
-                "mongodb-core": "3.0.8"
+                "mongodb-core": "3.0.1"
             }
         },
         "mongodb-core": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.8.tgz",
-            "integrity": "sha512-dFxfhH9N7ohuQnINyIl6dqEF8sYOE0WKuymrFf3L3cipJNrx+S8rAbNOTwa00/fuJCjBMJNFsaA+R2N16//UIw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.1.tgz",
+            "integrity": "sha1-/23Dbulv9ZaVPYCmhA1nMbyS7+0=",
             "dev": true,
             "requires": {
                 "bson": "1.0.6",
@@ -4259,40 +4244,40 @@
             }
         },
         "mongoose": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.1.2.tgz",
-            "integrity": "sha512-k9hssPMgBnUYG5e9NoUbx/2ERDyelDY0Vf6BwjtmoETUhVT7pQUe1o+oelLLuHF3ZVY2qgienK8pnrI5pdvlxA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.0.0.tgz",
+            "integrity": "sha512-ciHZSJsy37SpUXotPmhPR4uVXG6YEUDVAjPmYO3g5n7JCGnPeczH9ipwyCfDCORyu6vic2AKY0TMYW0WIuRdFA==",
             "dev": true,
             "requires": {
                 "async": "2.1.4",
                 "bson": "1.0.6",
-                "kareem": "2.1.0",
+                "kareem": "2.0.1",
                 "lodash.get": "4.4.2",
-                "mongodb": "3.0.8",
-                "mongoose-legacy-pluralize": "1.0.2",
-                "mpath": "0.4.1",
-                "mquery": "3.0.0",
+                "mongodb": "3.0.1",
+                "mongoose-legacy-pluralize": "1.0.1",
+                "mpath": "0.3.0",
+                "mquery": "3.0.0-rc0",
                 "ms": "2.0.0",
                 "regexp-clone": "0.0.1",
                 "sliced": "1.0.1"
             }
         },
         "mongoose-legacy-pluralize": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-            "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.1.tgz",
+            "integrity": "sha512-X5/N3sNj1p+y7Bg1vouQdST1vkInEzNAwqVjfDpNrhnugih2p2rV7jLrrb71sbQUPMJPm0Hhe6rH5fQV1Ve4XQ==",
             "dev": true
         },
         "mpath": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.4.1.tgz",
-            "integrity": "sha512-NNY/MpBkALb9jJmjpBlIi6GRoLveLUM0pJzgbp9vY9F7IQEb/HREC/nxrixechcQwd1NevOhJnWWV8QQQRE+OA==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
+            "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q=",
             "dev": true
         },
         "mquery": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.0.0.tgz",
-            "integrity": "sha512-WL1Lk8v4l8VFSSwN3yCzY9TXw+fKVYKn6f+w86TRzOLSE8k1yTgGaLBPUByJQi8VcLbOdnUneFV/y3Kv874pnQ==",
+            "version": "3.0.0-rc0",
+            "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.0.0-rc0.tgz",
+            "integrity": "sha512-tEAVSvlmd22irKJ8Q/tyI0LKRv8cV3aEkQ/EHW391ktGRWDDlfcpZyq6GYqu8yXGoz2JkC4aMJdNGca19wU1NQ==",
             "dev": true,
             "requires": {
                 "bluebird": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "lockgoose",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "Simple locking in mongo",
     "main": "index.js",
     "scripts": {
@@ -15,7 +15,7 @@
     "author": "Hubba",
     "license": "MIT",
     "peerDependencies": {
-        "mongoose": "^5.1.2"
+        "mongoose": "^5.0.0"
     },
     "dependencies": {},
     "devDependencies": {


### PR DESCRIPTION
The peer dependency was previously set to `^5.1.2` but it should be compatible with all of v5 so have reduced it to `^5.0.0`. Likely that we could offer compatibility with mongoose 4 in future.